### PR TITLE
Change deprecated Gemfile source `:rubygems` to `https://rubygems.org`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec
 


### PR DESCRIPTION
Removes deprecation warning on recent bundler
