### PR TITLE
Shef extensions have moved in 11.x, add compatible require

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,7 +41,11 @@ require 'chef/mixins'
 require 'chef/application'
 require 'chef/applications'
 
-require 'chef/shef'
+begin
+  require 'chef/shef'
+rescue LoadError
+  require 'chef/shef/ext'
+end
 require 'chef/util/file_edit'
 
 # If you want to load anything into the testing environment


### PR DESCRIPTION
Try to load old shef lib, otherwise fall through to load new shef extensions
