### PR TITLE
Implement `unwind` method. Closes #11

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+Hugo Lopes Tavares: Allow unwinding resources
 Peter Fern: Allow rewinding recipe_name
 Peter Fern: Shef extensions have moved in 11.x, add compatible require
 Peter Fern: Change deprecated Gemfile source `:rubygems` to `https://rubygems.org`

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Chef::Rewind
 
 This adds a simple function to the Chef library scope to
-rewind an existing resource. If the given resource does not exist, 
-a Chef::Exceptions::ResourceNotFound exception will be raised.
+rewind or unwind an existing resource. If the given resource does not exist, 
+a `Chef::Exceptions::ResourceNotFound` exception will be raised.
 
-This function is designed to assist the library cookbook pattern.
+These functions are designed to assist the library cookbook pattern.
 
-Effectively, the rewind resource allows you to monkeypatch a cookbook that you would rather not modify directly. It will modify some properties of a resource, during the complile phase, before chef-client actually starts the run phase.
+Effectively, rewind/unwind resource allows you to monkeypatch a cookbook that you would rather not modify directly. It will modify some properties of a resource, during the complile phase, before chef-client actually starts the run phase.
 
 ## Installation
 
@@ -23,6 +23,8 @@ Or install it yourself as:
     $ gem install chef-rewind
 
 ## Usage
+
+### rewind
 
 ```Ruby
 # file postgresql/recipes/server.rb
@@ -44,10 +46,72 @@ end
 
 ```
 
-The user "postgres" will act once with the home directory
-'/var/lib/pgsql/9.2 and the cookbook_name attribute is now
-"my-postgresql" instead of "postgresql". This last part is
+The user `postgres` will act once with the home directory
+`/var/lib/pgsql/9.2` and the `cookbook_name` attribute is now
+`my-postgresql` instead of `postgresql`. This last part is
 particularly important for templates and cookbook files.
+
+### unwind
+
+```Ruby
+# file postgresql/recipes/server.rb
+user "postgres" do
+  uid  26
+  home '/home/postgres'
+  supports  :manage_home => true
+end
+
+# file my-postgresql/recipes/server.rb
+chef_gem "chef-rewind"
+require 'chef/rewind'
+
+include_recipe "postgresql::server"
+
+unwind "user[postgres]"
+
+```
+
+This will completely remove the resource. It is useful
+for resources that are impossible to change correctly.
+Resource notifications, for example,
+can't be overwritten by `rewind`, only appended.
+
+So if you need to change notifications of a resource,
+you need to `unwind` and redefine the resource. Example:
+
+```Ruby
+# file cookbook-elasticsearch/recipes/default.rb
+template "logging.yml" do
+  path "#{node.elasticsearch[:path][:conf]}/logging.yml"
+  source "logging.yml.erb"
+  owner node.elasticsearch[:user] and group node.elasticsearch[:user] and mode 0755
+
+  notifies :restart, 'service[elasticsearch]'
+end
+
+# file my-elasticsearch/recipes/default.rb
+chef_gem "chef-rewind"
+require 'chef/rewind'
+
+unwind "template[logging.yml]"
+
+template "logging.yml" do
+  path  "#{node.elasticsearch[:path][:conf]}/logging.yml"
+  source "logging.yml.erb"
+  owner node.elasticsearch[:user] and group node.elasticsearch[:user] and mode 0755
+  cookbook_name "elasticsearch"
+
+  # this is the only change from original definition
+  notifies :run, 'execute[Custom ElasticSearch restarter]'
+end
+
+```
+
+This allows you to define your own ElasticSearch restart script.
+It's impossible to `rewind` notifications,
+thus you need to `unwind` and redefine it based on the original version.
+
+
 
 ## Gotchas *Important*
 

--- a/chef-rewind.gemspec
+++ b/chef-rewind.gemspec
@@ -3,8 +3,8 @@ $:.unshift(File.dirname(__FILE__) + '/lib')
 Gem::Specification.new do |gem|
   gem.authors       = ["Bryan Berry"]
   gem.email         = ["bryan.berry@gmail.com"]
-  gem.description   = %q{Monkey patches Chef to allow rewinding of existing resources}
-  gem.summary       = %q{Monkey patches Chef to allow rewinding of existing resources}
+  gem.description   = %q{Monkey patches Chef to allow rewinding and unwinding of existing resources}
+  gem.summary       = %q{Monkey patches Chef to allow rewinding and unwinding of existing resources}
   gem.homepage      = ""
 
   gem.files         = `git ls-files`.split($\)

--- a/lib/chef/rewind.rb
+++ b/lib/chef/rewind.rb
@@ -28,6 +28,20 @@ class Chef
         raise e
       end
     end
+
+    #  unwinds an existing resource if it exists,
+    #  otherwise raises the Chef::Exceptions::ResourceNotFound exception
+    #  For example:
+    #      #  recipe postgresql::server defines user "postgres"  and
+    #      #  sets the home directory to /var/pgsql/9.2
+    #      include_recipe "postgresql::user"
+    #
+    #      unwind "user[postgres]"
+    # === Parameters
+    # resource<String>:: String identifier for resource
+    def unwind(resource_id)
+      run_context.resource_collection.delete_resource resource_id
+    end
   end
 end
 
@@ -46,6 +60,19 @@ class Chef
                     :recipe_name,
                     arg,
                     :kind_of => String)
+    end
+  end
+end
+
+
+class Chef
+  class ResourceCollection
+    def delete_resource(resource_id)
+      lookup resource_id
+
+      # assumes `resource_id` is the same as `Chef::Resource#to_s`
+      @resources.delete_if {|r| r.to_s == resource_id }
+      @resources_by_name.delete resource_id
     end
   end
 end

--- a/spec/unwind_recipe_spec.rb
+++ b/spec/unwind_recipe_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+require 'chef/rewind'
+
+describe Chef::Recipe do
+  
+  before(:each) do
+    @cookbook_repo = File.expand_path(File.join(File.dirname(__FILE__), "..", "data", "cookbooks"))
+    cl = Chef::CookbookLoader.new(@cookbook_repo)
+    cl.load_cookbooks
+    @cookbook_collection = Chef::CookbookCollection.new(cl)
+    @node = Chef::Node.new
+    @node.normal[:tags] = Array.new
+    @events = Chef::EventDispatch::Dispatcher.new
+    @run_context = Chef::RunContext.new(@node, @cookbook_collection, @events)
+    @recipe = Chef::Recipe.new("hjk", "test", @run_context)
+  end
+
+
+  describe "unwind" do
+    it "should remove resource when unwind is called" do
+      @recipe.zen_master "foobar" do
+        peace false
+      end
+      
+      @recipe.unwind "zen_master[foobar]"
+
+      resources = @run_context.resource_collection.all_resources
+      resources.length.should == 0
+    end
+
+    it "should throw an error when unwinding a nonexistent resource" do
+      lambda do 
+        @recipe.unwind "zen_master[foobar]"
+      end.should raise_error(Chef::Exceptions::ResourceNotFound)
+    end
+  end
+
+end


### PR DESCRIPTION
This allows resources to be deleted.

I chose the name `unwind` because issue #11 cites it and I thought it would be a nice name because of `rewind`. But it looks confusing, and maybe we need to pick a different name.
