### PR TITLE
Fix README references to "cookbook_name"

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ end
 ```
 
 The user `postgres` will act once with the home directory
-`/var/lib/pgsql/9.2` and the `cookbook_name` attribute is now
+`/var/lib/pgsql/9.2` and the `cookbook` attribute is now
 `my-postgresql` instead of `postgresql`. This last part is
 particularly important for templates and cookbook files.
 
@@ -99,7 +99,7 @@ template "logging.yml" do
   path  "#{node.elasticsearch[:path][:conf]}/logging.yml"
   source "logging.yml.erb"
   owner node.elasticsearch[:user] and group node.elasticsearch[:user] and mode 0755
-  cookbook_name "elasticsearch"
+  cookbook "elasticsearch"
 
   # this is the only change from original definition
   notifies :run, 'execute[Custom ElasticSearch restarter]'
@@ -115,7 +115,7 @@ thus you need to `unwind` and redefine it based on the original version.
 
 ## Gotchas *Important*
 
-The rewind method does not automatically change the cookbook_name
+The rewind method does not automatically change the `cookbook`
 attribute for a resource to the current cookbook. Doing so could cause
 some unexpected behavior, particularly for less expert chef users.
 
@@ -136,12 +136,12 @@ include_recipe "postgresql::server"
 # my-postgresql.conf.erb located inside my-postgresql/templates/default/my-postgresql.conf.erb
 rewind :template => "/var/pgsql/data/postgresql.conf" do
   source "my-postgresql.conf.erb"
-  cookbook_name "my-postgresql"
+  cookbook "my-postgresql"
 end
 
 ```
 
-If you do not specify cookbook_name the rewind function will likely
+If you do not specify `cookbook` the rewind function will likely
 return an error since Chef will look in the postgresql cookbook for
 the source file and not in the my-postgresql cookbook.
 


### PR DESCRIPTION
The README refers to `cookbook_name` as an attribute of a resource specifying the location of the associated file, but that is incorrect; the attribute is simply `cookbook`.  There is a `cookbook_name` method, but it just returns the name of the cookbook containing the current recipe.
