### PR TITLE
Unwind resources that were defined more than once

### DIFF
--- a/lib/chef/rewind.rb
+++ b/lib/chef/rewind.rb
@@ -70,15 +70,24 @@ class Chef
     def delete_resource(resource_id)
       lookup resource_id
 
-      # assumes `resource_id` is the same as `Chef::Resource#to_s`
-      @resources.delete_if {|r| r.to_s == resource_id }
-      resource_index_value = @resources_by_name[resource_id]
-      @resources_by_name.each do |k, v|
-        @resources_by_name[k] = v - 1 if v > resource_index_value
+      indexes_to_delete = @resources.each_index.select do |resource_index|
+        # assumes `resource_id` is the same as `Chef::Resource#to_s`
+        @resources[resource_index].to_s == resource_id
       end
 
-      @resources_by_name.delete resource_id
+      # Delete indexes backwards to avoid problems with changing the array
+      indexes_to_delete.sort.reverse.each { |index| delete_index index }
 
+      @resources_by_name.delete resource_id
+    end
+
+    private
+
+    def delete_index(resource_index)
+      @resources.delete_at resource_index
+      @resources_by_name.each do |k, v|
+        @resources_by_name[k] = v - 1 if v > resource_index
+      end
     end
   end
 end

--- a/spec/unwind_recipe_spec.rb
+++ b/spec/unwind_recipe_spec.rb
@@ -32,7 +32,7 @@ describe Chef::Recipe do
       resources.length.should == 0
     end
 
-    it "should define resource completely when unwind is called" do
+    it "should delete resource completely when unwind is called" do
       @recipe.zen_master "foo" do
         action :nothing
         peace false
@@ -59,6 +59,24 @@ describe Chef::Recipe do
       lambda do
         @recipe.unwind "zen_master[foobar]"
       end.should raise_error(Chef::Exceptions::ResourceNotFound)
+    end
+
+    it "should correctly unwind a resource that was defined more than once" do
+      @recipe.zen_master "foo" do
+        peace true
+      end
+      @recipe.cat "blanket"
+      @recipe.zen_master "foo" do
+        peace false
+      end
+      @recipe.zen_master "bar"
+
+      @recipe.unwind "zen_master[foo]"
+
+      %w(zen_master[bar] cat[blanket]).each do |name|
+        resource = @run_context.resource_collection.lookup(name)
+        resource.to_s.should == name
+      end
     end
   end
 


### PR DESCRIPTION
This fixes a bug where a resource defined more than once would get removed from the `run_context.resources` array once per definition, but the indexes in `run_context.resources_by_name` would only get offset by 1.

The result of the bug was similar to #16, where lookup would return the wrong resources after an unwind.
